### PR TITLE
tanzanite: import keystore2 to vintf manifest

### DIFF
--- a/recovery/root/vendor/etc/vintf/manifest/android.system.keystore2-service.xml
+++ b/recovery/root/vendor/etc/vintf/manifest/android.system.keystore2-service.xml
@@ -1,0 +1,9 @@
+<manifest version="1.0" type="framework">
+    <hal format="aidl">
+        <name>android.system.keystore2</name>
+        <interface>
+            <name>IKeystoreService</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
servicemanager: Since 'android.system.keystore2.IKeystoreService/default' could not be found, trying to start it as a lazy AIDL service